### PR TITLE
Use structuredClone in paste-to-upload

### DIFF
--- a/paste-to-upload.user.js
+++ b/paste-to-upload.user.js
@@ -21,7 +21,7 @@
 
         document.getElementById("upload-file").click();
 
-        var files = info.clipboardData.files;
+        var files = structuredClone(info.clipboardData.files);
 
         setTimeout(() => {
             console.log(files);


### PR DESCRIPTION
Currently, in ViolentMonkey, the FileList is reset between the event handler and the setTimeout callback, so paste-to-upload always fails. Calling `structuredClone` makes a deep copy, so that when the original is reset, the copy is unaffected.